### PR TITLE
chore(deps): ignore unfixable undici advisory in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,8 @@ updates:
       prefix: "chore(deps)"
     cooldown:
       default-days: 2
+    ignore:
+      - dependency-name: "undici"
     groups:
       npm-dependencies:
         patterns:


### PR DESCRIPTION
## Summary

- Adds `ignore: [{dependency-name: "undici"}]` to the npm ecosystem block in `.github/dependabot.yml`
- `undici` is bundled inside npm/node-gyp/@semantic-release dev/release tooling — not a direct dependency, not shipped to runtime
- No upstream fix is available (`security_update_not_possible`); recurring Dependabot Updates runs fail because of these unapplicable alerts
- Alerts on personal-site (#83, #85, #86) have been dismissed as `tolerable_risk`

## Test plan
- [ ] Confirm dependabot.yml YAML is valid after merge
- [ ] Verify next Dependabot Updates run does not re-open undici alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)