### PR TITLE
chore(ci): add CodeQL security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL Security Scanning
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1'  # Weekly on Monday at 03:00 UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+        build-mode:
+          - none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

- Add `.github/workflows/codeql.yml` for GitHub CodeQL security scanning
- Targets `javascript-typescript` with `build-mode: none` (no build step needed)
- Uses `security-extended` query suite for comprehensive security coverage
- Triggers: push to `main`, PRs targeting `main`, and weekly schedule (Mondays 03:00 UTC)
- Uses `github/codeql-action` v3

## Test plan

- [ ] CodeQL workflow runs successfully on this PR
- [ ] Analysis completes with `success` conclusion
- [ ] Any security findings are reviewed and addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)