### PR TITLE
fix(security): use exact hostname check in parseNugetPackageId

### DIFF
--- a/lib/nuget.ts
+++ b/lib/nuget.ts
@@ -80,7 +80,7 @@ const getMappedPackagesForRepo = (fullName: string) => {
 export const parseNugetPackageId = (url: string) => {
     try {
         const parsed = new URL(url);
-        if (!parsed.hostname.includes('nuget.org')) return null;
+        if (parsed.hostname !== 'nuget.org' && !parsed.hostname.endsWith('.nuget.org')) return null;
         const parts = parsed.pathname.split('/').filter(Boolean);
         const packageIndex = parts.findIndex((part) => part.toLowerCase() === 'packages');
         if (packageIndex === -1) return null;


### PR DESCRIPTION
## Summary

- Fix CodeQL alert #1: `js/incomplete-url-substring-sanitization` (high severity) in `lib/nuget.ts`
- `hostname.includes('nuget.org')` could be bypassed by a crafted hostname such as `evil.nuget.org.attacker.com`
- Replace with `hostname === 'nuget.org' || hostname.endsWith('.nuget.org')` for exact/suffix matching

## Test plan

- [ ] CodeQL re-analysis clears alert #1 (`js/incomplete-url-substring-sanitization`)
- [ ] `npm run build` stays green
- [ ] NuGet package links from `nuget.org` still parse correctly; non-nuget URLs still return `null`

## False positives dismissed separately

The remaining 9 CodeQL alerts were dismissed as false positives via the GitHub API with justifications:
- **Alerts 2–6** (`js/request-forgery`): `fullName` is validated against a server-side allowlist before `buildPayload()` is called
- **Alerts 7** (`js/http-to-file-access`): Fetches from a fixed GitHub API URL and writes to a hardcoded path — no user-controlled data
- **Alerts 8–10** (`js/file-access-to-http`): Syndication script intentionally reads local post files and sends to fixed API endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)