### PR TITLE
chore(deps): ignore TypeScript major bumps until toolchain supports TS7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,8 @@ updates:
       default-days: 2
     ignore:
       - dependency-name: "undici"
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-dependencies:
         patterns:


### PR DESCRIPTION
Dependabot has been bumping `typescript` from 6.x to 7.0.2. TypeScript 7 is not yet supported by Next.js ("TypeScript 7.0.2 does not provide the compiler API required by Next.js"), so builds break.

This adds a `typescript` major-version ignore to the npm Dependabot entry to hold TypeScript at 6.x until Next.js supports TS7.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>